### PR TITLE
Fixes for newer htcondor

### DIFF
--- a/condor_config
+++ b/condor_config
@@ -69,7 +69,7 @@ BIN     = $(RELEASE_DIR)/bin
 LIB = $(RELEASE_DIR)/lib64/condor
 INCLUDE = $(RELEASE_DIR)/include/condor
 SBIN    = $(RELEASE_DIR)/sbin
-LIBEXEC = $(RELEASE_DIR)/libexec/condor
+LIBEXEC = $(RELEASE_DIR)/lib/condor/libexec
 SHARE   = $(RELEASE_DIR)/share/condor
 
 PROCD_ADDRESS = $(RUN)/procd_pipe

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:condor]
-command=/bin/bash -c "/etc/init.d/condor start"
+command=/usr/sbin/condor_master -f
 autostart=true
 stdout_logfile=/var/log/condor/condor.stdout.log
 stdout_logfile_maxbytes=1MB


### PR DESCRIPTION
I had to implement the following fixes to make your Docker image work:
- LIBEXEC in condor_config to allow master to start condor_shared_port
- command in supervisord.conf to start condor_master in foreground instead of the init script